### PR TITLE
ARGO-309 Support new POEM schema. Remove MRS related code.

### DIFF
--- a/src/config/templates/hosts.template
+++ b/src/config/templates/hosts.template
@@ -3,7 +3,6 @@ define host{
         notifications_enabled           1
         event_handler_enabled           1
         flap_detection_enabled          1
-        failure_prediction_enabled      1
         process_perf_data               1
         retain_status_information       1
         retain_nonstatus_information    1

--- a/src/config/templates/services.template
+++ b/src/config/templates/services.template
@@ -8,7 +8,6 @@ define service{
         notifications_enabled           1
         event_handler_enabled           1
         flap_detection_enabled          <ENABLE_FLAP_DETECTION>
-        failure_prediction_enabled      0
         process_perf_data               1
         retain_status_information       1
         retain_nonstatus_information    1

--- a/src/modules/NCG.pm
+++ b/src/modules/NCG.pm
@@ -18,7 +18,6 @@
 package NCG;
 
 use NCG::SiteDB;
-use DBI;
 
 # static variables used for path configuration variable in metric definitions
 # in config generation (ConfigGen module) they are replaced by:
@@ -96,72 +95,6 @@ sub getData
 {
     my $self = shift;
     $self->error("Method getData not implemented!");
-}
-
-sub getDatabaseDSN {
-    my $self = shift;
-    my $DRIVER = shift;
-    my $CONNECT = shift;
-    my $dsn;
-    $dsn = "DBI:" . $DRIVER . ":" . $CONNECT;
-    return $dsn;
-}
-
-
-sub connectDB {
-    my $self = shift;
-    my $DRIVER = shift;
-    my $CONNECT = shift;
-    my $USER = shift;
-    my $PASS = shift;
-    my $dbh = DBI->connect($self->getDatabaseDSN($DRIVER,$CONNECT),$USER,$PASS);
-    ($DBI::errstr) and
-        $self->error("Could not connect to database: $DBI::errstr ($DBI::err)") and
-        return;
-
-    $dbh;
-}
-
-sub query{
-    my $self = shift;
-    my $stmt = shift;
-    my $db=shift;
-    my $sth = $db->prepare($stmt);
-    my @fields;
-    my $arrRef;
-    my $sqlError;
-
-    if ($sth){
-        $DBI::errstr and $sqlError.="In prepare: $DBI::errstr\n";
-        $sth->execute;
-        $DBI::errstr and $sqlError.="In execute: $DBI::errstr\n";
-        $sth->{NAME} and @fields = @{$sth->{NAME}};
-        $arrRef = $sth->fetchall_arrayref;
-        $DBI::errstr and $sqlError.="In fetch: $DBI::errstr\n";
-        $sth->finish;
-        $DBI::errstr and $sqlError.="In finish: $DBI::errstr\n";
-    };
-
-    my @result;
-    for (@$arrRef) {
-        my %temphash;
-            for (my $i=0; $i<=$#fields; ++$i) {
-            if (defined(${$_}[$i])){
-                $temphash{$fields[$i]} = ${$_}[$i];
-            } else {
-                $temphash{$fields[$i]} = "";
-            }
-        }
-        push @result, \%temphash;
-        #print "1 $#fields..";
-    }
-
-    $sqlError and
-        $self->error("Database error: $sqlError.") and
-                return;
-
-
-    \@result;
 }
 
 sub _addRecurseDirs {

--- a/src/modules/NCG/ConfigGen/Nagios.pm
+++ b/src/modules/NCG/ConfigGen/Nagios.pm
@@ -121,8 +121,6 @@ sub new
         if (!defined $self->{ENABLE_NOTIFICATIONS} && ! defined $self->{SEND_TO_EMAIL});
     $self->{ENABLE_FLAP_DETECTION} = $DEFAULT_ENABLE_FLAP_DETECTION
         unless (defined $self->{ENABLE_FLAP_DETECTION});
-    $self->{LOCAL_METRIC_STORE} = 0
-        unless (defined $self->{LOCAL_METRIC_STORE});
     $self->{SEND_TO_MSG} = 1
         unless (defined $self->{SEND_TO_MSG});
     $self->{HOST_NOTIFICATIONS_OPTIONS} = "d,r"
@@ -479,7 +477,6 @@ sub _genCommands {
         $line =~ s/<NAGIOS_ROLE>/$self->{NAGIOS_ROLE}/g;
         $line =~ s/<NOTIFICATION_HEADER>/$self->{NOTIFICATION_HEADER}/g;
         $line =~ s/<NAGIOS_SERVER>/$self->{NAGIOS_SERVER}/g;
-        $line =~ s/<LOCAL_METRIC_STORE>/$self->{LOCAL_METRIC_STORE}/g;
         $line =~ s/<SEND_TO_DASHBOARD>/$sendToDashboard/g;
         $line =~ s/<SEND_TO_MSG>/$self->{SEND_TO_MSG}/g;
         print $CONFIG $line;
@@ -2572,10 +2569,6 @@ reference that can contain following elements:
 
   INCLUDE_LB_NODE - if true configuration for load balancing nodes
   will be generated.
-  (default: false)
-
-  LOCAL_METRIC_STORE - if true configuration for storing results to
-  local metric store.
   (default: false)
 
   MULTI_SITE_GLOBAL - if true only global configuration for multisite

--- a/src/modules/NCG/ConfigGen/Nagios.pm
+++ b/src/modules/NCG/ConfigGen/Nagios.pm
@@ -468,11 +468,7 @@ sub _genCommands {
     }
 
     my $sendToDashboard='';
-    my $ggusServerFqdn='';
 
-    if ($self->{GGUS_SERVER_FQDN}) {
-        $ggusServerFqdn = "--ggus-server $self->{GGUS_SERVER_FQDN}";
-    }
     if ($self->{SEND_TO_DASHBOARD}) {
         $sendToDashboard = "--send-to-dashboard";
     }
@@ -485,7 +481,6 @@ sub _genCommands {
         $line =~ s/<NAGIOS_SERVER>/$self->{NAGIOS_SERVER}/g;
         $line =~ s/<LOCAL_METRIC_STORE>/$self->{LOCAL_METRIC_STORE}/g;
         $line =~ s/<SEND_TO_DASHBOARD>/$sendToDashboard/g;
-        $line =~ s/<GGUS_SERVER_FQDN>/$ggusServerFqdn/g;
         $line =~ s/<SEND_TO_MSG>/$self->{SEND_TO_MSG}/g;
         print $CONFIG $line;
     }
@@ -1793,18 +1788,8 @@ sub _genServices {
             $custom->{"_service_flavour"} = $serviceType;
             $custom->{"_grid"} = $grids if ($grids);
             $custom->{"_server"} = $self->{NAGIOS_SERVER};
-            $custom->{"_last_notification_type"} = "";
-            $custom->{"_dashboard_notification_status"} = "";
-            $custom->{"_dashboard_notification_status_last_update"} = "";
-            if ($self->{GGUS_SERVER_FQDN}) {
-                $custom->{"_GGUS"} = "";
-            }
             if ($roc) {
                 $custom->{"_roc"} = $roc;
-            }
-
-            if ($obsess && ( $self->{GGUS_SERVER_FQDN} || $self->{SEND_TO_DASHBOARD} )) {
-                $contactgroupLocal .= ", msg-contacts";
             }
 
             $metricSgroup = $self->_getLocalServiceGroups($host, $metric, $servicegroups);
@@ -2573,11 +2558,6 @@ reference that can contain following elements:
                      a temporary location (e.g. ncg.reload.sh). final location
                      is needed for metrics with parameters stored in file
   (default: OUTPUT_DIR)
-
-  GGUS_SERVER_FQDN - if set to valid GGUS server handle_service_change will
-                    send notifications to GGUS
-                   - furthremore services which publish notifications will
-                   have _GGUS custom var added
 
   GLITE_VERSION - which version of Glite UI the tests will run on.
   (default: UNKNOWN)

--- a/src/modules/NCG/LocalMetrics/Hash.pm
+++ b/src/modules/NCG/LocalMetrics/Hash.pm
@@ -352,48 +352,6 @@ $WLCG_SERVICE->{'hr.srce.GridProxy-Get'}->{attribute}->{ROBOT_CERT} = "--robot-c
 $WLCG_SERVICE->{'hr.srce.GridProxy-Get'}->{attribute}->{ROBOT_KEY} = "--robot-key";
 $WLCG_SERVICE->{'hr.srce.GridProxy-Get'}->{attribute}->{PROXY_LIFETIME} = "--lifetime";
 
-# localdb.template
-$WLCG_SERVICE->{'org.egee.SendToMetricStore'}->{probe} = "send_to_db";
-$WLCG_SERVICE->{'org.egee.SendToMetricStore'}->{config}->{timeout} = 120;
-$WLCG_SERVICE->{'org.egee.SendToMetricStore'}->{config}->{interval} = 5;
-$WLCG_SERVICE->{'org.egee.SendToMetricStore'}->{config}->{retryInterval} = 2;
-$WLCG_SERVICE->{'org.egee.SendToMetricStore'}->{config}->{maxCheckAttempts} = 4;
-$WLCG_SERVICE->{'org.egee.SendToMetricStore'}->{config}->{path} = $NCG::NCG_PLUGINS_PATH_GRIDMON;
-$WLCG_SERVICE->{'org.egee.SendToMetricStore'}->{flags}->{NOHOSTNAME} = 1;
-$WLCG_SERVICE->{'org.egee.SendToMetricStore'}->{flags}->{PNP} = 1;
-$WLCG_SERVICE->{'org.egee.SendToMetricStore'}->{parameter}->{'--extra-opts'} = 'send_to_db@/etc/nagios/plugins/send_to_db.ini';
-
-$WLCG_SERVICE->{'ch.cern.sam.POEMSync'}->{probe} = "check_poem_sync";
-$WLCG_SERVICE->{'ch.cern.sam.POEMSync'}->{config}->{timeout} = 120;
-$WLCG_SERVICE->{'ch.cern.sam.POEMSync'}->{config}->{interval} = 30;
-$WLCG_SERVICE->{'ch.cern.sam.POEMSync'}->{config}->{retryInterval} = 10;
-$WLCG_SERVICE->{'ch.cern.sam.POEMSync'}->{config}->{maxCheckAttempts} = 4;
-$WLCG_SERVICE->{'ch.cern.sam.POEMSync'}->{config}->{path} = '/usr/bin/';
-$WLCG_SERVICE->{'ch.cern.sam.POEMSync'}->{flags}->{NOHOSTNAME} = 1;
-$WLCG_SERVICE->{'ch.cern.sam.POEMSync'}->{flags}->{NOARGS} = 1;
-
-$WLCG_SERVICE->{'org.egee.ATPSync'}->{probe} = "check_atp_sync";
-$WLCG_SERVICE->{'org.egee.ATPSync'}->{config}->{timeout} = 600;
-$WLCG_SERVICE->{'org.egee.ATPSync'}->{config}->{interval} = 30;
-$WLCG_SERVICE->{'org.egee.ATPSync'}->{config}->{retryInterval} = 15;
-$WLCG_SERVICE->{'org.egee.ATPSync'}->{config}->{maxCheckAttempts} = 4;
-$WLCG_SERVICE->{'org.egee.ATPSync'}->{config}->{path} = '/usr/bin/';
-$WLCG_SERVICE->{'org.egee.ATPSync'}->{flags}->{NOHOSTNAME} = 1;
-$WLCG_SERVICE->{'org.egee.ATPSync'}->{flags}->{NOARGS} = 1;
-
-$WLCG_SERVICE->{'org.nagios.MrsDirSize'}->{probe} = "org.nagiosexchange/check_dirsize.sh";
-$WLCG_SERVICE->{'org.nagios.MrsDirSize'}->{config}->{timeout} = 15;
-$WLCG_SERVICE->{'org.nagios.MrsDirSize'}->{config}->{interval} = 60;
-$WLCG_SERVICE->{'org.nagios.MrsDirSize'}->{config}->{retryInterval} = 5;
-$WLCG_SERVICE->{'org.nagios.MrsDirSize'}->{config}->{maxCheckAttempts} = 3;
-$WLCG_SERVICE->{'org.nagios.MrsDirSize'}->{config}->{path} = $NCG::NCG_PROBES_PATH_GRIDMON;
-$WLCG_SERVICE->{'org.nagios.MrsDirSize'}->{flags}->{NOHOSTNAME} = 1;
-$WLCG_SERVICE->{'org.nagios.MrsDirSize'}->{flags}->{PNP} = 1;
-$WLCG_SERVICE->{'org.nagios.MrsDirSize'}->{parameter}->{'-d'} = '/var/spool/nagios2metricstore';
-$WLCG_SERVICE->{'org.nagios.MrsDirSize'}->{parameter}->{'-w'} = '10000';
-$WLCG_SERVICE->{'org.nagios.MrsDirSize'}->{parameter}->{'-c'} = '100000';
-$WLCG_SERVICE->{'org.nagios.MrsDirSize'}->{parameter}->{'-f'} = '';
-
 # myproxy(.nrpe).template
 
 $WLCG_SERVICE->{'hr.srce.MyProxy-ProxyLifetime'}->{probe} = "hr.srce/MyProxy-probe";
@@ -512,43 +470,6 @@ $WLCG_SERVICE->{'org.nagios.NagiosCmdFile'}->{parameter}->{-o} = '';
 # $WLCG_SERVICE->{'org.nagios.NCGPidFile'}->{parameter}->{-c} = '172800';
 # $WLCG_SERVICE->{'org.nagios.NCGPidFile'}->{docurl} = "http://wiki.cro-ngi.hr/en/index.php/Org.nagios.NCGPidFile";
 
-# GoodCEs for SAM-WMS
-
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{probe} = "hr.srce/gather_healthy_nodes";
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{config}->{timeout} = 120;
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{config}->{interval} = 15;
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{config}->{retryInterval} = 5;
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{config}->{maxCheckAttempts} = 3;
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{config}->{path} = $NCG::NCG_PROBES_PATH_GRIDMON;
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{flags}->{NOHOSTNAME} = 1;
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{flags}->{PNP} = 1;
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{flags}->{VO} = 1;
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{flags}->{LOCALDEP} = 1;
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{flags}->{REQUIREMENT} = 'emi.wms.WMS-JobSubmit';
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{attribute}->{VONAME} = "--vo";
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{attribute}->{VO_FQAN} = "--vo-fqan";
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{parameter}->{'--dir'} = '/var/lib/gridprobes';
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{parameter}->{'--file'} = 'GoodCEs';
-$WLCG_SERVICE->{'hr.srce.GoodCEs'}->{parameter}->{"--metric"} = 'emi.cream.CREAMCE-JobSubmit';
-
-# GoodSEs for CE-JobState and WN-RepRep
-
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{probe} = "hr.srce/gather_healthy_nodes";
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{config}->{timeout} = 120;
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{config}->{interval} = 15;
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{config}->{retryInterval} = 5;
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{config}->{maxCheckAttempts} = 3;
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{config}->{path} = $NCG::NCG_PROBES_PATH_GRIDMON;
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{flags}->{NOHOSTNAME} = 1;
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{flags}->{PNP} = 1;
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{flags}->{VO} = 1;
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{flags}->{LOCALDEP} = 1;
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{attribute}->{VONAME} = "--vo";
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{attribute}->{VO_FQAN} = "--vo-fqan";
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{parameter}->{"--metric"} = 'org.sam.SRM-All';
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{parameter}->{'--dir'} = '/var/lib/gridprobes';
-$WLCG_SERVICE->{'hr.srce.GoodSEs'}->{parameter}->{'--file'} = 'GoodSEs';
-
 ########################################################################
 
 ########################################################################
@@ -617,43 +538,23 @@ $WLCG_NODETYPE->{security}->{"ARC-CE"} = [
 
 # Nagios internal checks profile
 $WLCG_NODETYPE->{internal}->{"NAGIOS"} = [
-'eu.egi.sec.CRL',
-'hr.srce.CADist-Check',
-'hr.srce.CADist-GetFiles',
 'hr.srce.CertLifetime',
 'org.nagios.DiskCheck',
 'org.nagios.ProcessCrond',
 'org.nagios.ProcessNpcd',
 'org.nagios.ProcessNSCA', # (if NRPE_UI is set)
 'org.egee.ImportGocdbDowntimes',
-'org.egee.SendToMetricStore', # (if LOCAL_METRIC_STORE)
-'org.egee.ATPSync', # (if LOCAL_METRIC_STORE)
-'ch.cern.sam.POEMSync', # (if LOCAL_METRIC_STORE)
-'ch.cern.sam.MrsCheckSpool',
-'ch.cern.sam.MrsCheckDBInserts',
-'org.nagios.MrsDirSize', # (if LOCAL_METRIC_STORE)
 'hr.srce.GridProxy-Valid', # (if INCLUDE_PROXY_CHECKS && local, NRPE)
 'hr.srce.GridProxy-Get', # (if INCLUDE_PROXY_CHECKS && local, NRPE)
-
 'org.egee.SendToMsg', # (if INCLUDE_MSG_SEND_CHECKS
 'org.egee.RecvFromQueue', # (if INCLUDE_MSG_CHECKS_RECV
 #'org.egee.CheckConfig', # (if INCLUDE_MSG_CHECKS_RECV
 'org.nagios.MsgDirSize', # (if INCLUDE_MSG_CHECKS_RECV || INCLUDE_MSG_SEND_CHECKS
 'org.nagios.ProcessMsgToHandler', # (if INCLUDE_MSG_CHECKS_RECV
 'org.nagios.MsgToHandlerPidFile', # (if INCLUDE_MSG_CHECKS_RECV
-'hr.srce.GoodCEs',
-'hr.srce.GoodSEs',
 'org.nagiosexchange.LogFiles',
 'org.nagios.NagiosCmdFile',
 'org.nagiosexchange.NCGLogFiles',
-'emi.cream.CREAMCE-JobMonit',
-'emi.cream.CREAMCE-DirectJobMonit',
-'emi.cream.glexec.CREAMCE-JobMonit',
-'emi.wms.WMS-JobMonit',
-'eu.egi.mpi.simplejob.CREAMCE-JobMonit',
-'eu.egi.mpi.complexjob.CREAMCE-JobMonit',
-'org.nordugrid.ARC-CE-monitor',
-'org.nordugrid.ARC-CE-clean',
 ];
 
 $WLCG_NODETYPE->{internal}->{"NRPE"} = [

--- a/src/modules/NCG/LocalMetricsAttrs/Active.pm
+++ b/src/modules/NCG/LocalMetricsAttrs/Active.pm
@@ -30,8 +30,6 @@ sub new {
     my $class  = ref($proto) || $proto;
     my $self =  $class->SUPER::new(@_);
 
-    $self->{LOCAL_METRIC_STORE} = 0
-        unless (defined $self->{LOCAL_METRIC_STORE});
     $self->{INCLUDE_MSG_CHECKS_RECV} = 1
         unless (defined $self->{INCLUDE_MSG_CHECKS_RECV});
     $self->{INCLUDE_MSG_CHECKS_SEND} = 1
@@ -109,13 +107,6 @@ sub _analyzeNAGIOS {
     if ($self->{SITEDB}->hasService($hostname, "NAGIOS")) {
         # NRPE service
         $self->{SITEDB}->removeMetric($hostname, undef, "org.nagios.ProcessNSCA") if (!$self->{NRPE_UI});
-        # local metric store checks
-        if (!$self->{LOCAL_METRIC_STORE}) {
-            $self->{SITEDB}->removeMetric($hostname, undef, "org.egee.SendToMetricStore");
-            $self->{SITEDB}->removeMetric($hostname, undef, "ch.cern.sam.POEMSync");
-            $self->{SITEDB}->removeMetric($hostname, undef, "org.egee.ATPSync");
-            $self->{SITEDB}->removeMetric($hostname, undef, "org.egee.MrsDirSize");
-        }
         # let's gather list of sites
         # needed for remote metrics and GOCDB downtimes
         my $siteList = join ( ',', keys %{$self->{MULTI_SITE_SITES}});
@@ -535,10 +526,6 @@ reference that can contain following elements:
   send results to the rest of the world over MSG.
   (default: true)
 
-  LOCAL_METRIC_STORE - if true configuration for storing results to
-  local metric store.
-  (default: false)
-  
   INCLUDE_PROXY_CHECKS - if true configuration for proxy generation
   will be generated. Set this option to 0 if there are no probes which
   require valid proxy certificate.

--- a/src/modules/NCG/SiteInfo/GOCDB.pm
+++ b/src/modules/NCG/SiteInfo/GOCDB.pm
@@ -191,7 +191,6 @@ Creates new NCG::SiteInfo::GOCDB instance. Argument $options is hash reference t
 can contains following elements:
   GOCDB_ROOT_URL - root URL used for GOCDB query interface
                  - only if GOCDB_ACCESS_TYPE is xml
-                 - default: https://goc.egi.eu/gocdbpi
 
   NODE_MONITORED - is node monitored (for possible values see GOCDB documentation)
                  - default: Y

--- a/src/modules/NCG/SiteInfo/GOCDB.pm
+++ b/src/modules/NCG/SiteInfo/GOCDB.pm
@@ -25,17 +25,12 @@ use vars qw(@ISA);
 
 @ISA=("NCG::SiteInfo");
 
-my $DEFAULT_GOCDB_ROOT_URL = "https://goc.egi.eu/gocdbpi";
 my $GOCDB_GET_METHOD = "/public/?method=get_service_endpoint";
 
 sub new {
     my $proto  = shift;
     my $class  = ref($proto) || $proto;
     my $self =  $class->SUPER::new(@_);
-
-    if (! $self->{GOCDB_ROOT_URL}) {
-        $self->{GOCDB_ROOT_URL} = $DEFAULT_GOCDB_ROOT_URL;
-    }
 
     if (! exists $self->{NODE_MONITORED}) {
         $self->{NODE_MONITORED} = 'Y';
@@ -61,7 +56,11 @@ sub getData {
 
     my $ua = LWP::UserAgent->new(timeout=>$self->{TIMEOUT}, env_proxy=>1);
     $ua->agent("NCG::SiteInfo::GOCDB");
-
+    
+    if (!$self->{GOCDB_ROOT_URL}) {
+        $self->error("Unable to fetch service endpoints from GOCDB. Please define a valid GOCDB url under SiteInfo section of NCG's configuration file.");
+        return 0;
+    }
     my $url = $self->{GOCDB_ROOT_URL} . $GOCDB_GET_METHOD . '&sitename=' . $sitename;
     if ($self->{NODE_MONITORED}) {
         $url .= '&monitored=' . $self->{NODE_MONITORED};

--- a/src/modules/NCG/SiteSet/GOCDB.pm
+++ b/src/modules/NCG/SiteSet/GOCDB.pm
@@ -25,7 +25,6 @@ use vars qw(@ISA);
 
 @ISA=("NCG::SiteSet");
 
-my $DEFAULT_GOCDB_ROOT_URL = "https://goc.egi.eu/gocdbpi";
 my $GOCDB_GET_METHOD = "/public/?method=get_site_list";
 
 sub new {
@@ -33,10 +32,6 @@ sub new {
     my $class  = ref($proto) || $proto;
     my $self =  $class->SUPER::new(@_);
 
-    # set default values
-    if (! $self->{GOCDB_ROOT_URL}) {
-        $self->{GOCDB_ROOT_URL} = $DEFAULT_GOCDB_ROOT_URL;
-    }
     if (! exists $self->{SITE_MONITORED}) {
         $self->{SITE_MONITORED} = 'Y';
     }
@@ -70,7 +65,11 @@ sub getData
 
     my $ua = LWP::UserAgent->new(timeout=>$self->{TIMEOUT}, env_proxy=>1);
     $ua->agent("NCG::SiteSet::GOCDB");
-
+    
+    if (!$self->{GOCDB_ROOT_URL}) {
+        $self->error("Unable to fetch sites from GOCDB API. Please define a valid GOCDB url under SiteSet section of NCG's configuration file.");
+        return 0;
+    }
     my $url = $self->{GOCDB_ROOT_URL} . $GOCDB_GET_METHOD;
     if ($self->{ROC}) {
         $url .= '&roc=' . $self->{ROC};

--- a/src/modules/NCG/SiteSet/GOCDB.pm
+++ b/src/modules/NCG/SiteSet/GOCDB.pm
@@ -161,7 +161,6 @@ Creates new NCG::SiteSet::GOCDB instance. Argument $options is hash reference th
 can contains following elements:
   GOCDB_ROOT_URL - root URL used for GOCDB query interface
                  - only if GOCDB_ACCESS_TYPE is xml
-                 - default: https://goc.egi.eu/gocdbpi
 
   ROC - name of the federation (for possible values see GOCDB documentation)
       - if not defined module will fetch all sites.


### PR DESCRIPTION
- [x] Update NCG POEM perl module to support the new json schema directly from the poem api call (example below).
- [x] Remove deprecated nagios flag `failure_prediction_enabled` .
- [x] Remove MRS related code including the nagios checks for the DB.
- [x] Remove default GOCDB urls from SiteSet and SiteInfo modules. Add proper error messages.

`poem_sync/api/0.1/json/metricinstances/`

```
[
  [
    "my.metric-TCP",
    "MY-CERVICE",
    "vo_name",
    <vo_fqan>
  ],
   ...
]
```

New call:
`poem/api/0.2/json/profiles`

```
[
  {
    name: "CRITICAL",
    atp_vo: "vo_name",
    version: "1.0",
    description: "Test monitoring",
    metric_instances: [
     {
       metric: "my.metric-TCP",
       fqan: "vo_fqan",
      vo: "vo_name",
      atp_service_type_flavour: "service_flavour_name"
     },
     ...
   ]
  }
]
```
