### PR TITLE
ARGO-355 NCG refactoring - parse extensions, remove deprecated functionality

### DIFF
--- a/src/modules/NCG/ConfigGen/Nagios.pm
+++ b/src/modules/NCG/ConfigGen/Nagios.pm
@@ -1912,6 +1912,7 @@ sub _genServices {
     $metricCount;
 }
 
+#TODO: Remove LB nodes support. getRealLocalMetrics() has been removed from SiteDB.
 sub _genLBServices {
     my $self = shift;
     my $CONFIG = shift;
@@ -2164,6 +2165,7 @@ sub _getHostGroups {
 # difference between _getHostGroups:
 #  - getRealServices is used for node-* groups
 #  - lbnode-* is used instead of alias-*
+#  TODO: Remove LB nodes support. getRealServices() has been removed from SiteDB.
 sub _getLBHostGroups {
 	my $self = shift;
     my $host = shift || return;
@@ -2369,6 +2371,7 @@ sub getData {
         }
 
         # Iterate through hosts which have LB nodes
+        # TODO: Remove LB nodes. getRealHosts(), LBNodeAddress(), getLBNodes(), hasLBNodes() have been removed from SiteDB.
         if ($self->{INCLUDE_LB_NODE}) {
             foreach my $host ($self->{SITEDB}->getRealHosts) {
                 next if ($self->{VO_HOST_FILTER} && !$self->_hostHasAnyVO($host));

--- a/src/modules/NCG/LocalMetricsAttrs/Active.pm
+++ b/src/modules/NCG/LocalMetricsAttrs/Active.pm
@@ -331,7 +331,7 @@ sub _analyzeURLs {
         if ($attr =~ /(\S+?:\/\/)?([-_.A-Za-z0-9]+):(\d+)/ ) {
             $self->{SITEDB}->hostAttribute($hostname, "QCG-NOTIFICATION_PORT", $3);
         }
-    }   
+    }
 
     my @unicoreServices = ("unicore6.Gateway", "unicore6.ServiceOrchestrator", "unicore6.StorageManagement", "unicore6.TargetSystemFactory", "unicore6.UVOSAssertionQueryService", "unicore6.WorkflowFactory", "unicore6.StorageFactory");
     foreach my $unicoreService (@unicoreServices) {

--- a/src/modules/NCG/SiteInfo/File.pm
+++ b/src/modules/NCG/SiteInfo/File.pm
@@ -62,6 +62,7 @@ sub new
     $self;
 }
 
+#TODO: Remove LB nodes support. addLBNode(), removeLBNode() have been removed from SiteDB.
 sub getData
 {
     my $self = shift;

--- a/src/modules/NCG/SiteInfo/GOCDB.pm
+++ b/src/modules/NCG/SiteInfo/GOCDB.pm
@@ -88,6 +88,7 @@ sub getData {
 
     foreach my $site ($doc->getElementsByTagName("SERVICE_ENDPOINT")) {
         my $elem;
+        my $subelem;
         my $hostname;
 
         if ($self->{PRODUCTION}) {
@@ -133,12 +134,29 @@ sub getData {
                         }
                     }
                 }
+                #FIXME: URL values inside subendpoints will overwrite any other url
                 foreach $elem ($site->getElementsByTagName("URL")) {
                     my $child = $elem->getFirstChild;
                     if ($child) {
                         my $value = $child->getNodeValue();
                         if ($value) {
                             $self->{SITEDB}->hostAttribute($hostname, $serviceType."_URL", $value);
+                        }
+                    }
+                }
+                foreach $elem ($site->getElementsByTagName("EXTENSIONS")) {
+                    foreach $subelem ($elem->getElementsByTagName("EXTENSION")) {
+                        my $k = $subelem->getElementsByTagName("KEY");
+                        my $k_item = $k->item(0);
+                        my $k_child = $k_item->getFirstChild;
+                        my $k_value = $k_child->getNodeValue();
+                        my $v = $subelem->getElementsByTagName("VALUE");
+                        my $v_item = $v->item(0);
+                        my $v_child = $v_item->getFirstChild;
+                        my $v_value = $v_child->getNodeValue();
+                        if ($k_value) {
+                            $self->{SITEDB}->hostAttribute($hostname, $serviceType."_".uc$k_value, $v_value);
+                            print "Found extension: $serviceType\.$k_value for host: $hostname \n";
                         }
                     }
                 }


### PR DESCRIPTION
# **Goal**
- Parse extensions section from GOCDB.
- Start refactoring basic structs to support more complex use cases eg. multiple same service_endpoints (host/service_type) with different urls.
- Remove REALHOSTS and Load Balancing nodes support
- Clean up code to improve readability.

GOCDB exposes via its `public/?method=get_service_endpoint` PI call custom attributes (extensions) in a form of key-value pairs. Modify NCG so it can parse those attributes and handle them as parameters inside service checks.

Example of the XML response:

```
<EXTENSIONS>
    <EXTENSION>
        <LOCAL_ID>1</LOCAL_ID>
        <KEY>my_key1</KEY>
       <VALUE>key1_value</VALUE>
    </EXTENSION>
    <EXTENSION>
        <LOCAL_ID>2</LOCAL_ID>
        <KEY>my_key2</KEY>
        <VALUE>key2_value</VALUE>
    </EXTENSION>
</EXTENSIONS>
</SERVICE_ENDPOINT>
```

NCG will then generate a list of GOCDB attributes per endpoint (extensions and other info that is available from the endpoint's details page). Those attributes will be used later as parameters in nagios check definitions.

In order to assign a specific extension to a metric one has to do the following:

1) Create the json metric definition that will be used as a reference by NCG
2) Assign parameters per extension under "attributes". Each entry must follow the convention `gocdbServiceType_KEY`.

e.g

```
{
   "my_check-TCP" : {
      "config" : {
         "interval" : 5,
         "maxCheckAttempts" : 3,
         "path" : "/usr/lib64/nagios",
         "retryInterval" : 3,
         "timeout" : 10
      },
      "attribute" : {
         "gocdbServiceType_USERNAME" : "--username",
         "gocdbServiceType_PASSWORD" : "--pass",
         "gocdbServiceType_PREFIX" : "--prefix"
      },
      "parameter" : {
         "-p" : 443
      },
      "probe" : "plugins/check_tcp"
   }
}
```

The configuration above will produce the following nagios service definition:

```
define service{
 [...]
        check_command                   /usr/lib64/nagios/plugins/check_tcp!10! --pass pass_key_value --username username_key_value --prefix prefix_key_value -p 443 
        normal_check_interval           5
        retry_check_interval            3
        max_check_attempts              3
        obsess_over_service             0
 [...]
}
```
# **Implementation**

Use the `SiteInfo::GOCDB` module to retrieve the data from gocdb.
Use the `hostAttribute()` to store the parsed data. At this point perhaps we should make a dedicated routine to handle the list of extensions so we can separate them from other gocdb attributes.
